### PR TITLE
Use `HOMEBREV_PREFIX` env variable if set

### DIFF
--- a/install
+++ b/install
@@ -1,8 +1,8 @@
 #!/System/Library/Frameworks/Ruby.framework/Versions/Current/usr/bin/ruby
 # This script installs to /usr/local only. To install elsewhere you can just
 # untar https://github.com/Homebrew/brew/tarball/master anywhere you like or
-# change the value of HOMEBREW_PREFIX.
-HOMEBREW_PREFIX = '/usr/local'
+# set the HOMEBREW_PREFIX environmental variable to the desired location.
+HOMEBREW_PREFIX = ENV.fetch('HOMEBREW_PREFIX', '/usr/local')
 HOMEBREW_CACHE = '/Library/Caches/Homebrew'
 HOMEBREW_REPO = 'https://github.com/Homebrew/brew'
 


### PR DESCRIPTION
I'd like to be able to easily install Homebrew to a custom location in
a non-interactive way (like Chef actually doing the work).  Current
method of editing the install file is not really suited for automated
use.
